### PR TITLE
Update build command usage on Windows

### DIFF
--- a/source/getting-started/build-host-setup.rst
+++ b/source/getting-started/build-host-setup.rst
@@ -27,9 +27,7 @@ Building on Windows
 
 Supported environment: **Microsoft Visual Studio 2015**
 
-.. note:: Different from Linux, you use ``BuildLoader.cmd`` instead of ``BuildLoader.py`` to compile, configure, stitch |SPN| image.
-
-Additionally, install the following software of **exact** versions (if specified) to the designated directories:
+Install the **exact** versions (if specified) of the following tools to the designated directories:
 
 * cxFreeze 4.3.3 (https://sourceforge.net/projects/cx-freeze/files/4.3.3/) - default installation path
 * Python 2.7 - **C:\\Python27**

--- a/source/tools/index.rst
+++ b/source/tools/index.rst
@@ -19,14 +19,9 @@ You can build |SPN| with the following options:
 * Change your payload files
 * Attach a version data structure of your own
 
+Command Syntax::
 
-For Linux::
-
-    $ python BuildLoader.py <subcommand> <target> <options>
-
-For Windows::
-
-    C:\SBL> BuildLoader.cmd <subcommand> <target> <options>
+    python BuildLoader.py <subcommand> <target> <options>
 
     <subcommand>  : build or clean
     <target>      : board name (e.g. apl or qemu)


### PR DESCRIPTION
BuildLoader.cmd is out-dated. Use BuildLoader.py
for both Windows and Linux build.

Signed-off-by: Huang Jin <huang.jin@intel.com>