### PR TITLE
Set generated HTML page as wide as possible

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -147,6 +147,9 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+def setup(app):
+   app.add_stylesheet("custom.css")
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/source/developer-guides/boot-flow.rst
+++ b/source/developer-guides/boot-flow.rst
@@ -43,6 +43,7 @@ End-to-End Call Graph
 The function call graph in |SPN| code from reset vector to OS launch.
 
 .. image:: /images/call_graph.png
+   :width: 600
    :alt: |SPN| Calling Graph
    :align: center
 

--- a/source/supported-hardware/up2.rst
+++ b/source/supported-hardware/up2.rst
@@ -21,6 +21,7 @@ Board Setup
 ^^^^^^^^^^^^^^^^^
 
 .. image:: /images/up2_setup.jpg
+   :width: 600
    :alt: |UP2| Board Setup
    :align: center
 


### PR DESCRIPTION
This makes easier to copy and paste long command lines embedded
in documents.

Signed-off-by: Huang Jin <huang.jin@intel.com>