### PR TITLE
Update documentation for iasimage Tool

### DIFF
--- a/source/tools/index.rst
+++ b/source/tools/index.rst
@@ -58,7 +58,6 @@ This tool is available on GitHub: |https://github.com/intel/iasimage|
 
    <a href="https://github.com/intel/iasimage" target="_blank">https://github.com/intel/iasimage</a>
 
-.. note:: Currently ``iasimage`` is only supported by Python 3 version.
 
 
 .. _stitch-tool:


### PR DESCRIPTION
iasimage tool now supports both Python 2.x and 3.x
(GitHub commit: b637605)

Signed-off-by: Huang Jin <huang.jin@intel.com>