### PR TITLE
Added updated information for Firmware Update

### DIFF
--- a/source/supported-hardware/apollo-lake-crb.rst
+++ b/source/supported-hardware/apollo-lake-crb.rst
@@ -84,10 +84,9 @@ Triggering Firmware Update
 
 Sample implementation of trigerring firmware update is explained below
 
-|SPN| for |APL| uses CMOS register 0x40 to trigger firmware update. When a value of 0x5A is found in CMOS register 0x40, |SPN| will set the boot mode to FLASH_UPDATE.
-please refer to IsFirmwareUpdate() function called in ``Platform\ApollolakeBoardPkg\Library\Stage1BBoardInitLib\Stage1BBoardInitLib.c`` to understand how |SPN| will detect firmware update mode.
+|SPN| for |APL| uses BIT16 of PMC I/O register (Scratchpad for sharing data between BIOS and PMC Firmware (BIOS_SCRATCHPAD) - Offset 1090h) to trigger firmware update. When BIT16 is set, |SPN| will set the boot mode to FLASH_UPDATE.
 
-.. note:: CMOS register can be accessed through IO ports 0x70 and 0x71
+please refer to IsFirmwareUpdate() function called in ``Platform\ApollolakeBoardPkg\Library\Stage1BBoardInitLib\Stage1BBoardInitLib.c`` to understand how |SPN| will detect firmware update mode.
 
 
 Debug UART

--- a/source/supported-hardware/up2.rst
+++ b/source/supported-hardware/up2.rst
@@ -124,10 +124,9 @@ Triggering Firmware Update
 
 Sample implementation of trigerring firmware update is explained below
 
-|SPN| for |UP2| uses CMOS register 0x40 to trigger firmware update. When a value of 0x5A is found in CMOS register 0x40, |SPN| will set the boot mode to FLASH_UPDATE.
-please refer to IsFirmwareUpdate() function called in ``Platform\ApollolakeBoardPkg\Library\Stage1BBoardInitLib\Stage1BBoardInitLib.c`` to understand how |SPN| will detect firmware update mode.
+|SPN| for |UP2| uses BIT16 of PMC I/O register (Scratchpad for sharing data between BIOS and PMC Firmware (BIOS_SCRATCHPAD) - Offset 1090h) to trigger firmware update. When BIT16 is set, |SPN| will set the boot mode to FLASH_UPDATE.
 
-.. note:: CMOS register can be accessed through IO ports 0x70 and 0x71
+please refer to IsFirmwareUpdate() function called in ``Platform\ApollolakeBoardPkg\Library\Stage1BBoardInitLib\Stage1BBoardInitLib.c`` to understand how |SPN| will detect firmware update mode.
 
 
 Flashing

--- a/source/supported-hardware/whl-cfl-crb.txt
+++ b/source/supported-hardware/whl-cfl-crb.txt
@@ -94,10 +94,10 @@ Triggering Firmware Update
 
 Sample implementation of trigerring firmware update is explained below
 
-|SPN| for |WHL|, |CFLR| or |UPX| uses CMOS register 0x40 to trigger firmware update. When a value of 0x5A is found in CMOS register 0x40, |SPN| will set the boot mode to FLASH_UPDATE.
+|SPN| for |WHL|, |CFLR| uses BIT16 of PMC I/O register (Over-Clocking WDT Control (OC_WDT_CTL) - Offset 54h) to trigger firmware update. When BIT16 is set, |SPN| will set the boot mode to FLASH_UPDATE.
+
 please refer to IsFirmwareUpdate() function called in ``Platform\CoffeelakeBoardPkg\Library\Stage1BBoardInitLib\Stage1BBoardInitLib.c`` to understand how |SPN| will detect firmware update mode.
 
-.. note:: CMOS register can be accessed through IO ports 0x70 and 0x71
 
 Debug UART
 ^^^^^^^^^^^


### PR DESCRIPTION
Following changes are made for firmware update documentation

1) Trigger from Operating system mechanism
2) 4-byte string id instead of GUID to identify components information
   capsule.
3) Container component update.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>