### PR TITLE
Update firmware update triggering info

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The generated HTML file is located in 'build'.
 1. Start a Python HTTP server from the documentation repo's root folder
 
 `cd <documentation repo root folder>`
-`python -m SimpleHTTPServer`
+For Python 2 do `python -m SimpleHTTPServer`, for Python 3 do `python -m http.server`
 
 2. Open your browser to load HTML page from http://localhost:8000/build
 

--- a/source/security/firmware-update.rst
+++ b/source/security/firmware-update.rst
@@ -287,9 +287,19 @@ EFI_FIRMWARE_MANAGEMENT_CAPSULE_HEADER is followed by one or multiple update ima
 Triggering Firmware Update 
 *****************************
 
-|SPN| supports triggering firmware update from Windows and |SPN| shell.
+|SPN| supports triggering firmware update from Linux, Windows, and |SPN| shell.
 
 |SPN| provides a platform independent abstracted way of triggering firmware update from operating system. |SPN| provides two ACPI methods, \DWMI.WQ00 for read and \DWMI.WS00 for write to a platform specific chipset register that can survive a reset to signal firmware update. Please refer to **Triggering Firmware Update** section of desired board page in **Supported Hardware** to find Sample implementation.
+
+Trigger Update From Linux Operating System
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your Linux kernel includes the Kconfig option `INTEL_WMI_SBL_FW_UPDATE` you can trigger a firmware update with the command below followed by restarting the system
+
+.. code-block:: bash
+
+  echo 1 > /sys/bus/wmi/devices/44FADEB1-B204-40F2-8581-394BBDC1B651/firmware_update_request
+  reboot
 
 Trigger Update From Windows Operating System
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -298,7 +308,7 @@ Users can use windows provided WMI service to call \DWMI.WQ00 and \DWMI.WS00 ACP
 
 A sample implementation of a VB script to call these methods from Windows operating system is provided below
 
-.. code-block:: guess
+.. code-block:: vbscript
 
     set Service = GetObject("winmgmts:root/wmi")
     set EnumSet = Service.InstancesOf ("AcpiFirmwareCommunication")


### PR DESCRIPTION
Recently support for triggering a FW update
via Linux kernel has been enabled, this patch
provides the details on how to trigger a FW
update if the Linux kernel supports it.

Also some other notes on HTTP server in Python3
and remove error message about guessing the syntax
of the Windows FW update triggering code block.

Signed-off-by: James Gutbub <james.gutbub@intel.com>