### PR TITLE
Add a note for container boot image requirements

### DIFF
--- a/source/how-tos/create-container-boot-image.rst
+++ b/source/how-tos/create-container-boot-image.rst
@@ -9,6 +9,7 @@ This page provides instructions for creating a bootable Linux kernel image in co
 
 The following step-by-step instructions is an example to boot Yocto kernel using container image format on |UP2|.
 
+.. important:: SBL Linux boot image containers typically include the kernel, kernel params and initramfs. The kernel then will mount the root file system from the boot media. There may be additional requirements in terms of configuration and layout for the kernel to locate and mount the root file system. If your boot image has some partition layout requirements, file/file-path dependencies, etc., you still need to adhere to those requirements when using container boot.
 
 **Step 1:** Download |CNT| and |CMU| to the same working directory to use the container tool.
 


### PR DESCRIPTION
Remind readers that if their boot image they want to
format as a container boot image is not able to launch
as a stand-alone boot image due to some other
requirements or dependencies their OS has (e.g. partition
labels/layout, files or file paths, etc.) that they
still need to ensure those requirements are met.

Signed-off-by: James Gutbub <james.gutbub@intel.com>