### PR TITLE
Update openssl to latest version

### DIFF
--- a/source/getting-started/build-host-setup.rst
+++ b/source/getting-started/build-host-setup.rst
@@ -113,24 +113,18 @@ Nasm 2.11
 
 Openssl (latest)
 
-Download from |https://indy.fulgan.com/SSL| (the latest version:  |https://indy.fulgan.com/SSL/openssl-1.0.2-x64_86-win64.zip|)
+Download latest win64 version from |https://wiki.openssl.org/index.php/Binaries|)
 
-.. |https://indy.fulgan.com/SSL| raw:: html
+.. |https://wiki.openssl.org/index.php/Binaries| raw:: html
 
-   <a href="https://indy.fulgan.com/SSL" target="_blank">https://indy.fulgan.com/SSL</a>
+   <a href="https://wiki.openssl.org/index.php/Binaries" target="_blank">https://wiki.openssl.org/index.php/Binaries</a>
 
-
-.. |https://indy.fulgan.com/SSL/openssl-1.0.2-x64_86-win64.zip| raw:: html
-
-   <a href="https://indy.fulgan.com/SSL/openssl-1.0.2-x64_86-win64.zip" target="_blank">https://indy.fulgan.com/SSL/openssl-1.0.2-x64_86-win64.zip</a>
-
- unzip then copy files to C:\\Openssl
 
 **Require:** Install to C:\\Openssl
 
 .. note::
-  Set environment variable OPENSSL_PATH to openssl directory,
-  Cmd: set OPENSSL_PATH=C:\\Openssl
+  Set environment variable OPENSSL_PATH to openssl directory where openssl.exe is present.
+  For example: set OPENSSL_PATH=C:\\Openssl\\bin
 
 
 Git on Windows

--- a/source/security/verified-boot.rst
+++ b/source/security/verified-boot.rst
@@ -22,7 +22,7 @@ SBL Hash Store
 
 SBL maintains a “Hash Store” to save digests needed by the bootloader. This includes the hash digests of |SPN| stages as well as the hash digests of the public keys used to verify discrete components.
 
-The hash store is included in Stage 1A and is verified as part of Stage 1B by the HWROT. The hash store can be extended using a loadable module as well. Stage 1B verifies this loadable module before extending the built-in hash store. 
+The hash store is included in Stage 1A and is verified as part of IBB by the HWROT. The hash store can be extended using a loadable module as well. Stage 1B verifies this loadable module before extending the built-in hash store. 
 
 
 Verified Boot FLow


### PR DESCRIPTION
User has to set OPENSSL_PATH to Openssl directort
    where openssl.exe is present.
    Updated documentation error in verified boot.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>