### PR TITLE
Ubuntu booting add note for BoardConfig.py setting

### DIFF
--- a/source/how-tos/boot-ubuntu.rst
+++ b/source/how-tos/boot-ubuntu.rst
@@ -7,7 +7,11 @@ Boot Ubuntu
 
 The following steps have been verified with Ubuntu Linux 18.04 LTS (64-bit).
 
+.. important:: Traditional Linux booting using vmlinuz, initrd, and config.cfg is only supported with the debug build of |SPN| or if you have **self.HAVE_VERIFIED_BOOT = 0** in your BoardConfig.py; you can test using debug build initially but for release build support consider packaging the vmlinuz, initrd, and config.cfg into container image format. See :ref:`create-container-boot-image` for more details.
+
 **STEP 1:** Build |SPN|
+
+.. note:: The BoardConfig.py option **self.ENABLE_GRUB_CONFIG = 1** should be set when building |SPN|.
 
 **STEP 2:** Flash IFWI image to the board
 


### PR DESCRIPTION
If attempting to boot Ubuntu using the GRUB config
details it is necessary to add the BoardConfig.py
setting self.ENABLE_GRUB_CONFIG = 1. This setting
may not always be enabled by default.

Also add an important note about how traditional Linux
boot is only enabled with debug build of SBL or if
you have verified boot disabled. This is because there
is no means of confirming the vmlinuz, initrd, or
config.cfg as trusted files unless you have packaged
them as a signed container image.

Signed-off-by: James Gutbub <james.gutbub@intel.com>