### PR TITLE
Resolve some stale example outputs

### DIFF
--- a/source/developer-guides/boot-options.rst
+++ b/source/developer-guides/boot-options.rst
@@ -6,7 +6,7 @@ Boot Options
 |SPN| supports boot options configuration for different boot targets. This feature is designed to provide flexibility and configurability, including:
 
 * Partition layout options (RAW, MBR, or GPT)
-* File system support (FAT and Ext2/3)
+* File system support (FAT and Ext2/3/4)
 * Multiple boot devices (eMMC, UFS, NVMe, SATA, USB, SPI flash etc)
 * Redundant and fallback options
 

--- a/source/how-tos/boot-vxworks.rst
+++ b/source/how-tos/boot-vxworks.rst
@@ -45,7 +45,7 @@ Depending on the boot media being used, ``container.bin`` should be copied to th
 
 Make sure the boot option is configured to the location of ``container.bin`` on the boot device. E.g., if ``container.bin`` is located on the first FAT32 partition on a USB, the boot option entry should look like the following::
 
-  # !BSF SUBT:{OS_TMPL:0 :  0    :  0 :   5   :  0   :   0  :    0 :    0 :'container.bin' }
+    - !expand { BOOT_OPTION_TMPL : [ 0 ,   0    ,  0 ,    5   ,   0   ,    0  ,     0 ,     0 , 'container.bin' ] }
 
 See :ref:`change-boot-options` for more details.
 

--- a/source/how-tos/change-boot-option.rst
+++ b/source/how-tos/change-boot-option.rst
@@ -123,11 +123,11 @@ For example, to switch boot options of index 0 and 3::
     Shell> boot
     Boot options (in HEX):
 
-    Idx|ImgType|DevType|Flags|DevAddr |HwPart|FsType|SwPart|File/Lbaoffset
-      0|      0|   MMC |   0 |    1C00|    0 |  FAT |    0 | iasimage.bin
-      1|      0|   MMC |   0 |    1C00|    0 | AUTO |    1 | iasimage.bin
-      2|      0|  SATA |   0 |    1200|    0 |  FAT |    0 | iasimage.bin
-      3|      0|   USB |   0 |    1500|    0 |  FAT |    0 | iasimage.bin
+    Idx|ImgType|DevType|DevNum|Flags|HwPart|FsType|SwPart|File/Lbaoffset
+      0|      0|   MMC |    0 |   0 |    0 |  FAT |    0 | iasimage.bin *Current
+      1|      0|   MMC |    0 |   0 |    0 | AUTO |    1 | iasimage.bin
+      2|      0|  SATA |    0 |   0 |    0 |  FAT |    0 | iasimage.bin
+      3|      0|   USB |    0 |   0 |    0 |  FAT |    0 | iasimage.bin
 
     SubCommand:
       s   -- swap boot order by index
@@ -142,11 +142,11 @@ For example, to switch boot options of index 0 and 3::
     Updated the Boot Option List
     Boot options (in HEX):
 
-    Idx|ImgType|DevType|Flags|DevAddr |HwPart|FsType|SwPart|File/Lbaoffset
-      0|      0|   USB |   0 |    1500|    0 |  FAT |    0 | iasimage.bin
-      1|      0|   MMC |   0 |    1C00|    0 | AUTO |    1 | iasimage.bin
-      2|      0|  SATA |   0 |    1200|    0 |  FAT |    0 | iasimage.bin
-      3|      0|   MMC |   0 |    1C00|    0 |  FAT |    0 | iasimage.bin
+    Idx|ImgType|DevType|DevNum|Flags|HwPart|FsType|SwPart|File/Lbaoffset
+      0|      0|   USB |    0 |   0 |    0 |  FAT |    0 | iasimage.bin *Current
+      1|      0|   MMC |    0 |   0 |    0 | AUTO |    1 | iasimage.bin
+      2|      0|  SATA |    0 |   0 |    0 |  FAT |    0 | iasimage.bin
+      3|      0|   MMC |    0 |   0 |    0 |  FAT |    0 | iasimage.bin
 
 
     Shell> exit

--- a/source/how-tos/create-container-boot-image.rst
+++ b/source/how-tos/create-container-boot-image.rst
@@ -51,7 +51,7 @@ Depending whether you are booting from eMMC or USB, ``container.bin`` should be 
 
 Make sure the boot option is configured to the location of ``container.bin`` on the boot device. E.g., if ``container.bin`` is located on the first boot FAT32 partition on USB, the boot option entry should look like the following::
 
-  # !BSF SUBT:{OS_TMPL:3 :  0    :  0 :   5   :  0   :   0  :    0 :    0 :'container.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     8   :   0    }
+    - !expand { BOOT_OPTION_TMPL : [ 3 ,   0    ,  0 ,    5   ,   0   ,    0  ,     0 ,     0 , 'container.bin' ] }
 
 See :ref:`change-boot-options` for more details.
 

--- a/source/how-tos/create-ias-boot-image.rst
+++ b/source/how-tos/create-ias-boot-image.rst
@@ -55,7 +55,7 @@ Depending whether you are booting from eMMC or USB, ``iasimage.bin`` should be c
 
 Make sure the boot option is configured to the location of ``iasimage.bin`` on the boot device. E.g., if ``iasimage.bin`` is located on the first boot FAT32 partition on USB, the boot option entry should look like the following::
 
-  # !BSF SUBT:{OS_TMPL:3 :  0    :  0 :   5   :  0   :   0  :    0 :    0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     8   :   0    }
+    - !expand { BOOT_OPTION_TMPL : [ 3 ,   0    ,  0 ,    5   ,   0   ,    0  ,     0 ,     0 , 'iasimage.bin' ] }
 
 See :ref:`change-boot-options` for more details.
 


### PR DESCRIPTION
There are a few places in the documentation where
some older output is being displayed which is
causing some confusion for readers. Update it to
reflect current code.

Signed-off-by: James Gutbub <james.gutbub@intel.com>