### PR TITLE
Update Nasm from 2.11 to 2.12.02

### DIFF
--- a/source/getting-started/build-host-setup.rst
+++ b/source/getting-started/build-host-setup.rst
@@ -17,7 +17,7 @@ Install the following software:
 
 * GCC 7.3 or above
 * Python 3.6 or above
-* NASM 2.11 or above
+* NASM 2.12.02 or above
 * IASL 20160422
 * OpenSSL
 * Git


### PR DESCRIPTION
SblOpen may have issue to build if using older
NASM versions; advise users to start using version
2.12.02 or newer:

https://www.nasm.us/pub/nasm/releasebuilds/

Signed-off-by: James Gutbub <james.gutbub@intel.com>