### PR TITLE
Enhance docs and clean up warnings in several docs

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -14,6 +14,7 @@
 
 import sys
 import os
+from datetime import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -50,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Slim Bootloader'
-copyright = u'2018, Intel Corporation'
+copyright = u'2018 - %s, Intel Corporation' % datetime.now().year
 author = u'Slim Bootloader Project'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/source/developer-guides/boot-flow.rst
+++ b/source/developer-guides/boot-flow.rst
@@ -109,7 +109,7 @@ Stage 2 performs the following initialization steps:
       )
 
 LdrGlobal - Loader Global Data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 The Loader Global Data structure is used to store important information throughout the different
 execution phases of the bootloader. It consists of information like available memory start and

--- a/source/developer-guides/build-system.rst
+++ b/source/developer-guides/build-system.rst
@@ -93,20 +93,27 @@ Slim Bootloader is built in stages and more information on each stage is given b
       the first DWORD of the built FV. The reset vector code from the Vtf0 jumps to this address and continues
       from the ``_ModuleEntryPoint`` defined in ``SecEntry.nasm``.
 
+  | 
 
 * **Stage 1B**:
 
   * **Packaged As**: FD containing Stage1B FV, and FSP-M binary as a FILE
   * **Stage 1B FV**: Contains ``CfgDataInt.bin``, and Stage1B PEIM
 
+  | 
+
 * **Stage 2**:
 
   * **Packaged As**: FD containing Stage2 FV, and FSP-S binary as a FILE
   * **Stage 2 FV**: Contains ACPI Table, Vbt, Logo, and Stage2 PEIM
 
+  | 
+
 * **OsLoader**:
 
   * **Packaged As**: FD containing OsLoader FV
+
+  | 
 
 * **FwUpdate**:
 
@@ -183,11 +190,15 @@ are pre-loaded into the SBL binary at pre-defined locations.
 
   * Address of HashStore is patched onto  ``PcdHashStoreBase`` PCD
 
+  | 
+
 * **Stage 1B:**
 
   * Stage 1B entry point address is patched into the Stage 1B ``__ModuleEntryPoint`` symbol address
   * Stage 1B module based is patched onto entry point + 4
   * Address of Internal CfgDataBase (GUID: ``016E6CD0-4834-4C7E-BCFE-41DFB88A6A6D``) is patched onto ``PcdCfgDataIntBase`` PCD
+
+  | 
 
 * **Stage 2:**
 

--- a/source/developer-guides/memory-map.rst
+++ b/source/developer-guides/memory-map.rst
@@ -52,6 +52,8 @@ Permanent Memory Map
   +------------------------------+  StackTop
   |       LDR Stack (Down)       |
   |                              |
+  |                              |
+  |                              |
   |         LDR HOB (Up)         |
   +------------------------------+  MemPoolEnd (Fixed)
   |    Global Data structures    |      |

--- a/source/how-tos/configure-memory-down.rst
+++ b/source/how-tos/configure-memory-down.rst
@@ -35,13 +35,15 @@ For |UP2|, open ``CfgData_Ext_Up2.dlt`` and customize values that match the actu
 
 Optionally, you can use |CFGTOOL| to graphically view and modify configurations. See https://slimbootloader.github.io/developer-guides/configuration.html for details.
 
-.. note:: If FSP UPD implementation supports hardcoded SPD table, simply replacing the SPD binary file under ``<platform>\CfgData``. The file name of a SPD binary can be found in ``<platform>\CfgData\CfgData_MemSpd.yaml``. If a platform supports more than one type of memory configuration, the ``MEMORY_CFG_DATA.SpdDataSel`` must be carefully set. Take Tiger Lake as an example: Spd_Ddrlp4.bin and Spd_Ddrlp5.bin are for LPDDR4 and LPDDR5 respectivly. The index of Spd_Ddrlp4.bin is 1, and it is 2 for Spd_Ddrlp5.bin. In a board dlt file::
+.. note:: If FSP UPD implementation supports hardcoded SPD table, simply replacing the SPD binary file under ``<platform>\CfgData``. The file name of a SPD binary can be found in ``<platform>\CfgData\CfgData_MemSpd.yaml``. If a platform supports more than one type of memory configuration, the ``MEMORY_CFG_DATA.SpdDataSel`` must be carefully set. Take Tiger Lake as an example: Spd_Ddrlp4.bin and Spd_Ddrlp5.bin are for LPDDR4 and LPDDR5 respectivly. The index of Spd_Ddrlp4.bin is 1, and it is 2 for Spd_Ddrlp5.bin.
+  
+    In a board dlt file::
 
-  MEMORY_CFG_DATA.SpdAddressTable  | {..., 0, ... } <-- when 0, FSP will use hardcoded SPD for the memory slot (mem controller X, channel Y, Dimm Z). Otherwise, FSP reads its SPD from the smbus address.
+      MEMORY_CFG_DATA.SpdAddressTable  | {..., 0, ... } <-- when 0, FSP will use hardcoded SPD for the memory slot (mem controller X, channel Y, Dimm Z). Otherwise, FSP reads its SPD from the smbus address.
 
-  MEMORY_CFG_DATA.SpdDataSelXYZ    | 1  <-- using LPDDR4 hardcoded SPD for memory slot XYZ. Or
+      MEMORY_CFG_DATA.SpdDataSelXYZ    | 1  <-- using LPDDR4 hardcoded SPD for memory slot XYZ. Or
 
-  MEMORY_CFG_DATA.SpdDataSelXYZ    | 2  <-- using LPDDR5
+      MEMORY_CFG_DATA.SpdDataSelXYZ    | 2  <-- using LPDDR5
 
 Step 3 - Build, stitch and test
 

--- a/source/how-tos/integrate-multiple-payloads.rst
+++ b/source/how-tos/integrate-multiple-payloads.rst
@@ -17,7 +17,11 @@ You can integrate more than one payload files using |SPN| build tool::
                                This parameter is optional, and default is 'Dummy' if not specified.
 
 If only one payload is specified, this payload will be built into normal payload compoment (PYLD) in the SBL flash map.
+
+
 If more then one payloads are specified, the first payload will be built into PLD and the remaining will be built into extended payload container (EPLD) in the SBL flash map.
+
+  .. note:: EPAYLOAD is built as an SBL Container (Refer :ref:`gen-container-tool`) and then put into the EPLD region.
 
 The following procedure shows you how to integrate ``UefiPld.fd`` into |SPN| image. Adding other custom payloads is similar.
 

--- a/source/security/key-management.rst
+++ b/source/security/key-management.rst
@@ -5,6 +5,7 @@ A sample implementation of signing service is provided by *SingleSign.py* and is
 Customers may use different signing infrastructure including use of secure signing servers, etc. and the SingleSign.py can be updated/replaced with customer’s signing infrastructure.
 
 .. _key-management:
+
 Key Management
 ---------------
 

--- a/source/supported-hardware/icdx-crb.rst
+++ b/source/supported-hardware/icdx-crb.rst
@@ -99,13 +99,13 @@ Flash the generated ``sbl_idv_ifwi.bin`` to the target board using a DediProg SF
     #. The programmer is set to update the flash from offset 0x0.
 
 SPI header on Brightoncity Board (R1K5)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. image:: /images/lcc_spi.png
    :width: 600
    :alt: |ICXD| SPI Header on Brightoncity board (R1K5)
 
 SPI header on Morocity Board (J2G6)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. image:: /images/hcc_spi.png
    :width: 600
    :alt: |ICXD| SPI Header on Morocity board (J2G6)

--- a/source/tools/BuildTool.rst
+++ b/source/tools/BuildTool.rst
@@ -3,6 +3,9 @@
 Build Tool
 -----------
 
+Introduction
+^^^^^^^^^^^^
+
 ``BuildLoader.py`` compiles source code with all the *magics* to generate output image(s). It provides two subcommands: build and clean.
 
 
@@ -13,6 +16,9 @@ You can build |SPN| with the following options:
 * Use debug image of FSP
 * Change your payload files
 * Attach a version data structure of your own
+
+Usage
+^^^^^
 
 Command Syntax::
 
@@ -48,4 +54,61 @@ If build is successful, ``Outputs`` folder will contain the build binaries. One 
 
 |SPN| supports a single image supporting up to 32 board configurations for the same type of board or platform. To add multi-board support, see :ref:`configuration-feature`.
 
+Working
+^^^^^^^
 
+The overall flow of the build process is shown below:
+
+* Environment initialization
+* Early build initialization
+
+  * Toolchains and dependencies are verified
+  * BaseTools are compiled
+
+* Board build hook: ``pre-build: before``
+
+  * Create build directory
+  * Generate dlt file from CfgData
+
+* Pre-build:
+
+  * Make sure SBL signing keys exist
+  * Build or grab FSP
+  * Create Firmware Interface Table (FIT)
+  * Create Bootloader Version Info file
+  * Create VBT
+  * Create DSC file for build
+  * Rebase FSP
+  * Create config data
+  * Build reset vector // Note - clarify
+
+* Board build hook: ``pre-build:after``
+
+  * User can specify if any processing needs to be done at this point and can add relevant functionality to this build hook
+
+* Call EDK-II's ``build`` command
+
+* Board build hook: ``post-build: before``
+
+  * User can specify if any processing needs to be done at this point and can add relevant functionality to this build hook
+
+* Post-build:
+
+  * Generate binaries for:
+
+    * UEFI Variable Storage
+    * ACM and Diagnostic ACM
+    * MRC Training Data
+    * Bootloader Variable storage
+    * Microcode
+    * Payload and EPayload
+    * FW Update
+
+  * Generate container images
+  * Patch stages
+  * Create redundant components
+  * Stitch
+
+* Board build hook: ``post-build: after``
+
+  * User can specify if any processing needs to be done at this point and can add relevant functionality to this build hook

--- a/source/tutorials/ex_corrupt_sbl_component.rst
+++ b/source/tutorials/ex_corrupt_sbl_component.rst
@@ -60,7 +60,7 @@ Command Example::
 After one or more corruptions, a reset should be run to exercise SBL with the corruptions.
 
 Behavior when SBL component is corrupted
-*************************************
+****************************************
 
 If SBL resiliency is enabled and an SBL component is corrupted, the system halts for some
 time after hash verification of the corrupted component fails. If an IBB corruption is present (i.e. a


### PR DESCRIPTION
- Make footer copyright year update automatically
- Add clarification about EPLD region
- Add heading to build tool doc
- Clean up warnings about section links, length of underlines, etc.
- Adjust whitespace in Build System doc
- Fix reference to key management section