### PR TITLE
Fix typo and links in UP board setup

### DIFF
--- a/source/supported-hardware/up2-6000.rst
+++ b/source/supported-hardware/up2-6000.rst
@@ -27,7 +27,7 @@ Prerequisites
 
 .. |USB 2.0 pin header cable| raw:: html
 
-   <a href="https://up-shop.org/up-peripherals/110-usb-20-pin-header-cable.html" target="_blank">USB 2.0 pin header cable</a>
+   <a href="https://up-shop.org/usb-2-0-pin-header-cable.html" target="_blank">USB 2.0 pin header cable</a>
 
 
 Board Setup

--- a/source/supported-hardware/up2.rst
+++ b/source/supported-hardware/up2.rst
@@ -23,7 +23,7 @@ Prerequisites
 
 .. |Model N3350| raw:: html
 
-   <a href="https://up-shop.org/home/270-up-squared.html" target="_blank">Model N3350</a>
+   <a href="https://up-shop.org/up-squared-series.html" target="_blank">Model N3350</a>
 
 .. |instructions| raw:: html
 
@@ -31,7 +31,7 @@ Prerequisites
 
 .. |USB 2.0 pin header cable| raw:: html
 
-   <a href="https://up-shop.org/up-peripherals/110-usb-20-pin-header-cable.html" target="_blank">USB 2.0 pin header cable</a>
+   <a href="https://up-shop.org/usb-2-0-pin-header-cable.html" target="_blank">USB 2.0 pin header cable</a>
 
 
 Board Setup

--- a/source/supported-hardware/upxtremei11.rst
+++ b/source/supported-hardware/upxtremei11.rst
@@ -27,7 +27,7 @@ Prerequisites
 
 .. |USB 2.0 pin header cable| raw:: html
 
-   <a href="https://up-shop.org/up-peripherals/110-usb-20-pin-header-cable.html" target="_blank">USB 2.0 pin header cable</a>
+   <a href="https://up-shop.org/usb-2-0-pin-header-cable.html" target="_blank">USB 2.0 pin header cable</a>
 
 
 Board Setup

--- a/source/supported-hardware/upxtremei12.rst
+++ b/source/supported-hardware/upxtremei12.rst
@@ -79,7 +79,7 @@ Stitching
 
 Stitch |SPN| images with factory BIOS image using the stitch tool::
 
-    python Platform/AlderlakeBoardPkg/Script/StitchLoader.py -i <BIOS_IMAGE_NAME> -s Outputs/tgl/SlimBootloader.bin -o <SBL_IFWI_IMAGE_NAME> -p 0xAA000104
+    python Platform/AlderlakeBoardPkg/Script/StitchLoader.py -i <BIOS_IMAGE_NAME> -s Outputs/adlp/SlimBootloader.bin -o <SBL_IFWI_IMAGE_NAME> -p 0xAA000104
 
     <BIOS_IMAGE>     : Input file. Factory BIOS extracted from UP Xtreme i12 board.
     <SBL_IFWI_IMAGE> : Output file. New IFWI image with SBL in BIOS region.


### PR DESCRIPTION
Fixed typo in UPX i12
Updated links in all UP boards.