### PR TITLE
Update Dockerfile to fix CVE-2020-11022

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+dist: jammy
+
 services:
   - docker
 
@@ -8,9 +10,10 @@ before_install:
   - mkdir -p build publish
   - chmod 777 build publish
   - touch publish/.nojekyll
+  - export GIT_SAFE_DIR_CMD="git config --global --add safe.directory /docs" # Fix error caused by CVE-2022-24765 Git update
 
 script:
-  - docker run --rm -v ${PWD}:/docs -w /docs sbl_docs make publish BUILDDIR=/docs/build PUBLISHDIR=/docs/publish
+  - docker run --rm -v ${PWD}:/docs -w /docs sbl_docs /bin/bash -c "${GIT_SAFE_DIR_CMD} && make publish BUILDDIR=/docs/build PUBLISHDIR=/docs/publish"
 
 deploy:
   provider: pages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get update
-RUN apt-get -y install python python-pip graphviz
-RUN pip install sphinx==1.8.1 docutils==0.14 sphinx-rtd-theme==0.4.2 sphinxcontrib-websupport==1.1.0
+RUN apt-get -y install python3 python3-pip graphviz git
+RUN pip install sphinx==6.1.3 docutils==0.18.1 sphinx-rtd-theme==1.2.0 sphinxcontrib-websupport==1.2.4 sphinxcontrib-jquery
 
 RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.graphviz',
     'sphinx.ext.todo',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
- Update Docker to Ubuntu 22.04 base
- Add sphinx_rtd_theme to site's conf.py as required by newer Sphinx versions
- This will fix CVE-2020-11022 as detected by GitHub IPAS scan