### PR TITLE
Set English as the default language

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -68,7 +68,7 @@ release = u'1.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Fixes the following build warning of a language not being set

"WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English)."