### PR TITLE
Set Ruby version to 2.7 to fix deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ sudo: required
 
 dist: jammy
 
+# Set Ruby version to 2.6 to fix deployment
+# It seems that some Ruby Gems haven't been updated to support Ruby 3.0
+rvm:
+  - 2.7.8
+
 services:
   - docker
 


### PR DESCRIPTION
It seems that some Ruby Gems haven't been updated to support Ruby 3.0

https://travis-ci.community/t/github-release-fail-after-ruby-version-update/13214/9