### PR TITLE
Downgrade Travis VM to Focal (20.04) to try to fix deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 sudo: required
 
-dist: jammy
-
-# Set Ruby version to 2.6 to fix deployment
-# It seems that some Ruby Gems haven't been updated to support Ruby 3.0
-rvm:
-  - 2.7.8
+dist: focal
 
 services:
   - docker


### PR DESCRIPTION
Newer Ubuntu versions are having an issue with build and deployment Ruby versions being mistmatched

Default Ruby version is 2.7 so we don't need to set it explicitly