### PR TITLE
fix typing error (typo) on IASL version

### DIFF
--- a/source/getting-started/build-host-setup.rst
+++ b/source/getting-started/build-host-setup.rst
@@ -18,7 +18,7 @@ Install the following software:
 * GCC 9.4.0 or above
 * Python 3.8.10 or above
 * NASM 2.16.01 or above
-* IASL 20190509LLVM
+* IASL 20190509
 * LLVM (needed for UEFI payload build)
 * OpenSSL
 * Git


### PR DESCRIPTION
removing the "LLVM" in IASL version line