### PR TITLE
fix: llvm installation on Windows

### DIFF
--- a/source/getting-started/build-host-setup.rst
+++ b/source/getting-started/build-host-setup.rst
@@ -133,6 +133,8 @@ LLVM 15.0.7
 
 **Require:** Install to C:\\LLVM
 
+.. note::
+  Add an environment variable: CLANG_BIN=C:\LLVM\bin\
 
 Openssl (latest)
 


### PR DESCRIPTION
Because the doc asks users to install LLVM to C:\LLVM, it is better to add the CLANG_BIN env variable. Otherwise, the build system may use C:\Program Files\LLVM\bin, which does not exist if a user only installs LLVM to C:\LLVM.