### PR TITLE
fix: Properly escape backslashes in CLANG_BIN variable

### DIFF
--- a/source/getting-started/build-host-setup.rst
+++ b/source/getting-started/build-host-setup.rst
@@ -153,7 +153,7 @@ LLVM 15.0.7
 **Require:** Install to C:\\LLVM
 
 .. note::
-  Add an environment variable: CLANG_BIN=C:\LLVM\bin\
+  Add an environment variable: CLANG_BIN=C:\\LLVM\\bin\\
 
 Openssl (latest)
 


### PR DESCRIPTION
Fixed escape prefix for backslashes in CLANG_BIN environtment variable example.