### PR TITLE
Fix OsLoader terminology consistency

### DIFF
--- a/source/developer-guides/flashmap.rst
+++ b/source/developer-guides/flashmap.rst
@@ -44,7 +44,7 @@ UCOD       Microcode Patch
 MRCD       MRC training data
 VARS       Variable data
 KEYH       Key hash store
-PYLD       Normal Payload (typically OS loader)
+PYLD       Normal Payload (typically OsLoader)
 EPLD       Extended Payload container (UEFI payload, Linux payload, etc)
 IAS1       First IAS image (typically for provisioning or recovery use)
 IAS2       Second IAS image

--- a/source/developer-guides/payload.rst
+++ b/source/developer-guides/payload.rst
@@ -8,10 +8,10 @@ Payloads
 Payloads
 ^^^^^^^^^^^^^^^^^^^
 
-Os Loader (Built-in)
+OsLoader (Built-in)
   A versatile linux loader implementation that boots Linux, ELF, UEFI-PI FV, or PE executables. It also supports launching OSes compliant with the MultiBoot specification.
 
-  When built as an FV formatted payload OS Loader permits the inclusion and launching of a pre-OS payload binary that will hand-off control to an OS after the pre-OS payload finishes execution.
+  When built as an FV formatted payload OsLoader permits the inclusion and launching of a pre-OS payload binary that will hand-off control to an OS after the pre-OS payload finishes execution.
 
   See :ref:`enable-pre-os-payload` for more details.
 
@@ -50,7 +50,7 @@ A payload can be **Tightly Coupled** or **Loosely Coupled** with Slim Bootloader
 Multiple Payload Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In some use cases, more than one payload is necessary in |SPN|. However, it is difficult to fit all payloads into limited flash device. For example, UEFI payload image can be over 1MB in size. This feature is designed to support multiple payloads, allowing built-in payload (OsLoader) reside in redundant region, while the **external** payloads in non-redundant region.
+In some use cases, more than one payload is necessary in |SPN|. However, it is difficult to fit all payloads into limited flash device. For example, UEFI payload image can be over 1MB in size. This feature is designed to support multiple payloads, allowing built-in payload (OsLoader) to reside in redundant region, while the **external** payloads in non-redundant region.
 
 See :ref:`integrate-multiple-payloads` for more details.
 

--- a/source/how-tos/boot-ubuntu.rst
+++ b/source/how-tos/boot-ubuntu.rst
@@ -3,9 +3,9 @@
 Boot Ubuntu
 ------------
 
-|SPN| can boot Ubuntu Linux using |SPN| with default OS loader. This page provides a step-by-step guide how to do so.
+|SPN| can boot Ubuntu Linux using |SPN| with default OsLoader. This page provides a step-by-step guide how to do so.
 
-.. note:: OS Loader payload is capable of booting Ubuntu if it was installed using UEFI Payload. See :ref:`note-on-boot-option` for details on configuring your boot option to support Ubuntu booting with OS Loader.
+.. note:: OsLoader payload is capable of booting Ubuntu if it was installed using UEFI Payload. See :ref:`note-on-boot-option` for details on configuring your boot option to support Ubuntu booting with OsLoader.
 
 The following steps have been verified with Ubuntu Linux 20.04 LTS (64-bit).
 

--- a/source/how-tos/enable-pre-os-payload.rst
+++ b/source/how-tos/enable-pre-os-payload.rst
@@ -3,7 +3,7 @@
 Enable Pre-OS Payload Support
 -----------------------------
 
-Pre-OS payload support is an additional feature supported by |SPN| via OS Loader payload in which OS Loader will load both the main OS and a pre-OS payload into memory and will pass control to the pre-OS payload instead of the main OS. After the pre-OS payload finishes execution it is expected that the pre-OS payload will pass control to the main OS that OS Loader previously loaded into memory.
+Pre-OS payload support is an additional feature supported by |SPN| via OsLoader payload in which OsLoader will load both the main OS and a pre-OS payload into memory and will pass control to the pre-OS payload instead of the main OS. After the pre-OS payload finishes execution it is expected that the pre-OS payload will pass control to the main OS that OsLoader previously loaded into memory.
 
 Pre-OS payload support can only be enabled or disabled at build time.
 
@@ -13,8 +13,8 @@ In ``BoardConfig.py`` change/add the following entry::
 
 A pre-OS payload binary needs to be provided in the ``Platform/<Platform_Foo>/Binaries/`` directory and named as ``PreOsChecker.bin``.
 
-When this is enabled the OS Loader payload should be used in FV format so that ``PreOsChecker.bin`` is included into the payload per the ``BootloaderCorePkg/BootloaderCorePkg.fdf`` [FV.OsLoader] section.
+When this is enabled the OsLoader payload should be used in FV format so that ``PreOsChecker.bin`` is included into the payload per the ``BootloaderCorePkg/BootloaderCorePkg.fdf`` [FV.OsLoader] section.
 
-To use OS Loader payload as an FV in |SPN| run the ``BuildLoader.py`` command with the ``-p`` argument as given below::
+To use OsLoader payload as an FV in |SPN| run the ``BuildLoader.py`` command with the ``-p`` argument as given below::
 
   python BuildLoader.py build <platform_name> -p OsLoader.Fv:LLDR:Lz4


### PR DESCRIPTION
Replace inconsistent references to "OS Loader" and "Os Loader" with "OsLoader" format in documentation text while preserving boot log output examples.